### PR TITLE
Remove named function in publish which would not subscribe

### DIFF
--- a/package.js
+++ b/package.js
@@ -1,7 +1,7 @@
 /* global Package*/
 Package.describe({
     name: 'socialize:user-blocking',
-    version: '1.0.2',
+    version: '1.0.3',
     summary: 'Allow users to block each other',
     git: 'https://github.com/copleykj/socialize-user-blocking.git',
 });

--- a/package.js
+++ b/package.js
@@ -1,16 +1,16 @@
 /* global Package*/
 Package.describe({
     name: 'socialize:user-blocking',
-    version: '1.0.3',
+    version: '1.0.5',
     summary: 'Allow users to block each other',
     git: 'https://github.com/copleykj/socialize-user-blocking.git',
 });
 
 Package.onUse(function _(api) {
-    api.versionsFrom('1.3');
+    api.versionsFrom('1.8.3');
     api.use([
         'check',
-        'reywood:publish-composite@1.7.0',
+        'reywood:publish-composite@1.7.3',
         'socialize:user-model@1.0.2',
     ]);
     api.imply('socialize:user-model');

--- a/server/publications.js
+++ b/server/publications.js
@@ -11,7 +11,7 @@ const optionsArgumentCheck = {
     sort: Match.Optional(Object),
 };
 
-publishComposite('socialize.blockedUsers', function publishBlockedUsers(options = { limit: 10, sort: { createdAt: -1 } }) {
+publishComposite('socialize.blockedUsers', function(options = { limit: 10, sort: { createdAt: -1 } }) {
     check(options, optionsArgumentCheck);
     if (!this.userId) {
         return this.ready();
@@ -37,7 +37,7 @@ publishComposite('socialize.blockedUsers', function publishBlockedUsers(options 
  * Publication to check if the current user is blocking the given user.
  * @param lookupUserId {String}
  */
-publishComposite('socialize.blocksUserById', function publishBlockedUsers(lookupUserId) {
+publishComposite('socialize.blocksUserById', function(lookupUserId) {
     check(lookupUserId, String);
     if (!this.userId) {
         return this.ready();


### PR DESCRIPTION
Having publications named would not return anything upon subscription (or at least not return a ready flag).